### PR TITLE
Increase StatsD message max length

### DIFF
--- a/ngx_http_statsd.c
+++ b/ngx_http_statsd.c
@@ -18,7 +18,12 @@
 #define STATSD_TYPE_COUNTER	0x0001
 #define STATSD_TYPE_TIMING  0x0002
 
-#define STATSD_MAX_STR 256
+/*
+ * Max StartsD message length = 1472
+ * - 1 ASCII character = 1 byte
+ * - 1 UDP packet payload = 1472 bytes ( 1500-20-8 )
+*/
+#define STATSD_MAX_STR 1472
 
 #define ngx_conf_merge_ptr_value(conf, prev, default)            		\
  	if (conf == NGX_CONF_UNSET_PTR) {                               	\


### PR DESCRIPTION
This change increases the max length of our StatsD messages from
`256` to `1472`. The new value was chosen based on the max
payload of a UDP packet.

This change lines up with how the metrics manager reads in stats.

Fixes #ENGT-10851