### PR TITLE
Removed -lssl reference from CORE_LIBS

### DIFF
--- a/config
+++ b/config
@@ -1,4 +1,3 @@
 ngx_addon_name=ngx_http_statsd
 HTTP_MODULES="$HTTP_MODULES ngx_http_statsd_module"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_statsd.c"
-CORE_LIBS="$CORE_LIBS -lssl"


### PR DESCRIPTION
This reference was making nginx always link with openssl dynamically on CentOS. Openssl doesn't seem to be needed by this module, but even if it is it's already provided in our nginx build.

Master PR: https://github.com/apcera/nginx-router/pull/96

Fixes #ENGT-11304